### PR TITLE
Add parser for replacing regular underscores with full-width underscores

### DIFF
--- a/TSMarkdownParser/TSMarkdownParser.h
+++ b/TSMarkdownParser/TSMarkdownParser.h
@@ -125,6 +125,8 @@ typedef void (^TSMarkdownParserLinkFormattingBlock)(NSMutableAttributedString *a
 - (void)addMonospacedParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 /// accepts "**text**", "__text__"
 - (void)addStrongParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
+/// accepts groups of 4 or more underscores (low line: u005f) & replaces them with unicode fullwidth underscores (fullwidth low line: uff3f)
+- (void)addUnderscoreReplacementParsing;
 /// accepts "*text*", "_text_"
 - (void)addEmphasisParsingWithFormattingBlock:(TSMarkdownParserFormattingBlock)formattingBlock;
 /// accepts "***text***", "___text___"

--- a/TSMarkdownParser/TSMarkdownParser.m
+++ b/TSMarkdownParser/TSMarkdownParser.m
@@ -89,6 +89,8 @@ typedef NSFont UIFont;
     
     /* escaping parsing */
     
+    [defaultParser addUnderscoreReplacementParsing];
+
     [defaultParser addCodeEscapingParsing];
     
     [defaultParser addEscapingParsing];
@@ -256,8 +258,20 @@ static NSString *const TSMarkdownMonospaceRegex     = @"(`+)(\\s*.*?[^`]\\s*)(\\
 static NSString *const TSMarkdownStrongRegex        = @"(\\*\\*|__)(.+?)(\\1)";
 static NSString *const TSMarkdownEmRegex            = @"(\\*|_)(.+?)(\\1)";
 static NSString *const TSMarkdownStrongEmRegex      = @"(((\\*\\*\\*)(.|\\s)*(\\*\\*\\*))|((___)(.|\\s)*(___)))";
+static NSString *const TSMarkdownUnderscoreReplacementRegex = @"(_{4,})";
 
 #pragma mark escaping parsing
+
+- (void)addUnderscoreReplacementParsing {
+    NSRegularExpression *parsing = [NSRegularExpression regularExpressionWithPattern:TSMarkdownUnderscoreReplacementRegex options:NSRegularExpressionDotMatchesLineSeparators error:nil];
+    [self addParsingRuleWithRegularExpression:parsing block:^(NSTextCheckingResult *match, NSMutableAttributedString *attributedString) {
+        NSRange range = [match rangeAtIndex:1];
+        // replace groups of 4 or more underscores (low line: u005f) with unicode fullwidth underscore (fullwidth low line: uff3f)
+        NSString *matchString = [attributedString attributedSubstringFromRange:range].string;
+        NSString *replacementString = [matchString stringByReplacingOccurrencesOfString:@"_" withString:@"＿"];
+        [attributedString replaceCharactersInRange:range withString:replacementString];
+    }];
+}
 
 - (void)addCodeEscapingParsing {
     NSRegularExpression *parsing = [NSRegularExpression regularExpressionWithPattern:TSMarkdownCodeEscapingRegex options:NSRegularExpressionDotMatchesLineSeparators error:nil];


### PR DESCRIPTION
This PR replaces groups of 4 or more regular underscores with full-width underscores.  This is necessary because Apple's regex matcher hangs on the strong+emphasis parser when it encounters groups of 4 or more regular underscores.